### PR TITLE
Do not depend on `@opentelemetry/sdk-trace-base`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,6 +1407,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
       "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.18.1",
         "@opentelemetry/semantic-conventions": "1.18.1"
@@ -1422,6 +1423,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
       "integrity": "sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==",
+      "dev": true,
       "dependencies": {
         "@opentelemetry/core": "1.18.1",
         "@opentelemetry/resources": "1.18.1",
@@ -9350,11 +9352,8 @@
     },
     "packages/opentelemetry-baggage-span-processor": {
       "name": "@uphold/opentelemetry-baggage-span-processor",
-      "version": "0.0.0",
+      "version": "0.0.2",
       "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/sdk-trace-base": "^1.18.1"
-      },
       "devDependencies": {
         "@opentelemetry/sdk-trace-node": "^1.18.1"
       },

--- a/packages/opentelemetry-baggage-span-processor/package.json
+++ b/packages/opentelemetry-baggage-span-processor/package.json
@@ -42,9 +42,6 @@
       "eslint --ext .ts,.js"
     ]
   },
-  "dependencies": {
-    "@opentelemetry/sdk-trace-base": "^1.18.1"
-  },
   "peerDependencies": {
     "@opentelemetry/api": ">=1 <2"
   },

--- a/packages/opentelemetry-baggage-span-processor/src/baggage-span-processor.ts
+++ b/packages/opentelemetry-baggage-span-processor/src/baggage-span-processor.ts
@@ -1,13 +1,22 @@
 import { Context, Span, propagation } from '@opentelemetry/api';
-import { NoopSpanProcessor } from '@opentelemetry/sdk-trace-base';
 
-export class BaggageSpanProcessor extends NoopSpanProcessor {
-  override onStart(span: Span, parentContext: Context): void {
+export class BaggageSpanProcessor {
+  onStart(span: Span, parentContext: Context): void {
     // Set all baggage entries as span attributes.
     const baggageEntries = propagation.getBaggage(parentContext)?.getAllEntries();
 
     baggageEntries?.forEach(([key, baggageEntry]) => {
       span.setAttribute(key, baggageEntry.value);
     });
+  }
+
+  onEnd(): void {}
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
Multiple versions of `@opentelemetry/sdk-trace-base` in projects generate problems, like instrumentations not being loaded / registered. This pull-request removes the unnecessary dependency of `@opentelemetry/sdk-trace-base` to prevent these issues now and in the future.