### PR TITLE
Prepare for v1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10035,7 +10035,7 @@
     },
     "packages/opentelemetry-baggage-span-processor": {
       "name": "@uphold/opentelemetry-baggage-span-processor",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@opentelemetry/sdk-trace-node": "^1.30.0"
@@ -10049,7 +10049,7 @@
     },
     "packages/opentelemetry-mutable-baggage": {
       "name": "@uphold/opentelemetry-mutable-baggage",
-      "version": "0.0.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/core": "^1.30.0"

--- a/packages/opentelemetry-baggage-span-processor/package.json
+++ b/packages/opentelemetry-baggage-span-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uphold/opentelemetry-baggage-span-processor",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Package that sets all baggage entries as span attributes.",
   "main": "dist/index.js",
   "files": [

--- a/packages/opentelemetry-mutable-baggage/package.json
+++ b/packages/opentelemetry-mutable-baggage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uphold/opentelemetry-mutable-baggage",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "description": "Package that allows an OpenTelemetry baggage to be mutable.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
We can't publish 1.0.0 since it was wrongly published and we must now publish 1.1.0