### PR TITLE
Remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Description

Removes the repository-level `.npmrc`, whose sole content was:

```
//registry.npmjs.org/:_authToken=${NPM_TOKEN}
```

This file configured an npm registry auth token (via the `NPM_TOKEN` env var) for publishing.

> [!NOTE]
> If this repo publishes to npm via CI, ensure the registry authentication is provided through another mechanism (e.g. the publish workflow itself) so publishing is not broken by this removal.

## Related issues
N/A

## Impacted areas
npm publish / package installation configuration.

## Steps to reproduce or test
#### Development
N/A — file removal only.

#### QA
N/A

## Checklist
- [ ] Add label `Breaking Change` if it applies.
- [ ] Commits are atomic and logically separated.
- [ ] Performance implications have been considered.
- [ ] Security implications have been considered.
- [ ] The new and updated code has good coverage.
- [ ] [API documentation](https://uphold.com/en/developer/api/documentation/), if required, has been created or updated.
- [ ] New dependencies have been added to `package.json`.
- [ ] The README file, if required, has been updated.
- [ ] [Architectural diagram](https://cloudcraft.co/app), if required, has been updated.

## Deploy notes
N/A